### PR TITLE
Wrong namespace on Session.php

### DIFF
--- a/Session.php
+++ b/Session.php
@@ -10,7 +10,7 @@
  * @license http://vistart.name/license/
  */
 
-namespace app\mongodb;
+namespace vistart\mongodb;
 
 use Yii;
 use yii\base\ErrorHandler;


### PR DESCRIPTION
Wrong namespace on Session.php causes PSR-4 autoloader exception class vistart\mongodb\Session not exists